### PR TITLE
Fix missing `pub` on the helper GAT trait(s)

### DIFF
--- a/src/proc_macros/gat-attr/trait_def.rs
+++ b/src/proc_macros/gat-attr/trait_def.rs
@@ -86,9 +86,11 @@ fn handle (
             &generics.where_clause,
         );
         let LGat { attrs, .. } = &lgat;
+        let pub_ = &trait_.vis;
         ret.extend(quote!(
             #(#attrs)*
             #[allow(warnings, clippy::all)]
+            #pub_
             trait #TraitName <#intro_generics>
             #where_clause
             {


### PR DESCRIPTION
Using `#[nougat]` on a `pub` trait would fail due to the missing `pub` privacy of the helper GAT trait.