### PR TITLE
Extend macro to append additional `use`s.

### DIFF
--- a/src/compile_fail_tests.md
+++ b/src/compile_fail_tests.md
@@ -1,12 +1,35 @@
 # The following snippets fail to compile
 
-### The `#[gat]` attribute takes no args
+### The `#[gat]` attribute takes no args for trait declarations
 
 ```rust ,compile_fail
 use ::nougat::*;
 
 #[gat(dyn)]
 trait Foo {}
+```
+
+### The `#[gat]` attribute only allows one item in imports
+
+```rust ,compile_fail
+// for some reason we need to surround this in a module,
+// otherwise the inner module imports don't resolve correctly,
+// and the compile failure is not the right failure we test.
+mod provider {
+
+use ::nougat::*;
+#[gat]
+trait Foo { type Item<'item> where Self: 'item; }
+struct Bar;
+
+mod inner {
+    use ::nougat::*;
+
+    #[gat(Item)]
+    use super::{Foo, Bar};
+}
+}
+
 ```
 
 <!-- Templated by `cargo-generate` using https://github.com/danielhenrymantilla/proc-macro-template -->

--- a/src/proc_macros/gat-attr/_mod.rs
+++ b/src/proc_macros/gat-attr/_mod.rs
@@ -2,6 +2,7 @@ use super::*;
 
 mod trait_def;
 mod trait_impl;
+mod trait_use;
 
 pub(in super)
 fn gat (
@@ -9,10 +10,13 @@ fn gat (
     input: TokenStream2,
 ) -> Result<TokenStream2>
 {
-    let _: parse::Nothing = parse2(attrs)?;
     match parse2(input)? {
         | Item::Trait(item_trait) => trait_def::handle(item_trait),
         | Item::Impl(item_impl) => trait_impl::handle(item_impl),
+        | Item::Use(item_use) => {
+            let assoc_types = Punctuated::<NestedMeta, syn::token::Comma>::parse_terminated.parse2(attrs)?;
+            trait_use::handle(item_use, &assoc_types)
+        }
         | _ => bail!("expected a `trait` or an `impl… Trait for`"),
     }
     .map(utils::mb_file_expanded)

--- a/src/proc_macros/gat-attr/_mod.rs
+++ b/src/proc_macros/gat-attr/_mod.rs
@@ -11,8 +11,14 @@ fn gat (
 ) -> Result<TokenStream2>
 {
     match parse2(input)? {
-        | Item::Trait(item_trait) => trait_def::handle(item_trait),
-        | Item::Impl(item_impl) => trait_impl::handle(item_impl),
+        | Item::Trait(item_trait) => {
+            let _: parse::Nothing = parse2(attrs)?;
+            trait_def::handle(item_trait)
+        },
+        | Item::Impl(item_impl) => {
+            let _: parse::Nothing = parse2(attrs)?;
+            trait_impl::handle(item_impl)
+        },
         | Item::Use(item_use) => {
             let assoc_types = Punctuated::<NestedMeta, syn::token::Comma>::parse_terminated.parse2(attrs)?;
             trait_use::handle(item_use, &assoc_types)

--- a/src/proc_macros/gat-attr/_mod.rs
+++ b/src/proc_macros/gat-attr/_mod.rs
@@ -20,7 +20,7 @@ fn gat (
             trait_impl::handle(item_impl)
         },
         | Item::Use(item_use) => {
-            let assoc_types = Punctuated::<NestedMeta, syn::token::Comma>::parse_terminated.parse2(attrs)?;
+            let assoc_types = Punctuated::<Ident, Token![,]>::parse_terminated.parse2(attrs)?;
             trait_use::handle(item_use, &assoc_types)
         }
         | _ => bail!("expected a `trait` or an `impl… Trait for`"),

--- a/src/proc_macros/gat-attr/trait_use.rs
+++ b/src/proc_macros/gat-attr/trait_use.rs
@@ -93,11 +93,11 @@ fn find_use_path_and_name<'item>(
                 }
             }
             bail!("expected a single item in this import, e.g.\n\
-                `use path::to::Trait`, or `use path::to::Trait as Renamed`")
+                `use path::to::Trait`, or `use path::to::Trait as Renamed`" => use_group)
         }
-        UseTree::Glob(_) => {
+        UseTree::Glob(glob) => {
             bail!("expected a single item in this import, e.g.\n\
-                    `use path::to::Trait`, or `use path::to::Trait as Renamed`")
+                    `use path::to::Trait`, or `use path::to::Trait as Renamed`" => glob)
         }
     }
 }

--- a/src/proc_macros/gat-attr/trait_use.rs
+++ b/src/proc_macros/gat-attr/trait_use.rs
@@ -4,8 +4,7 @@ pub(super) fn handle(
     assoc_type_use: ItemUse,
     assoc_types: &Punctuated<NestedMeta, syn::token::Comma>,
 ) -> Result<TokenStream2> {
-    let (use_segments, use_name) = find_use_path_and_name(Vec::new(), &assoc_type_use.tree)?;
-    let trait_name = &use_name.ident;
+    let (use_segments, name_type) = find_use_path_and_name(Vec::new(), &assoc_type_use.tree)?;
 
     let assoc_typenames = assoc_types
         .iter()
@@ -21,15 +20,35 @@ pub(super) fn handle(
             }
         })
         .try_fold::<_, _, std::result::Result<_, Error>>(
-            Vec::<Ident>::with_capacity(assoc_types.len()),
+            Vec::<TokenStream2>::with_capacity(assoc_types.len()),
             |mut assoc_uses, assoc_type_path| {
                 let assoc_type_path = assoc_type_path?;
                 let assoc_type = assoc_type_path
                     .last()
                     .expect("Expected exactly one segment in the path");
-                let assoc_typename =
-                    combine_trait_name_and_assoc_type(trait_name, &assoc_type.ident);
-                assoc_uses.push(assoc_typename);
+
+                match name_type {
+                    NameType::Name(use_name) => {
+                        // Push a list of `TraitඞData`
+                        let trait_name = &use_name.ident;
+                        let assoc_typename =
+                            combine_trait_name_and_assoc_type(trait_name, &assoc_type.ident);
+
+                        assoc_uses.push(quote!(#assoc_typename));
+                    },
+                    NameType::Rename(use_rename) => {
+                        // Push a list of `TraitඞData as TraitRenamedඞData`
+                        let trait_name = &use_rename.ident;
+                        let trait_rename = &use_rename.rename;
+
+                        let assoc_typename =
+                            combine_trait_name_and_assoc_type(trait_name, &assoc_type.ident);
+                        let assoc_typename_rename =
+                            combine_trait_name_and_assoc_type(trait_rename, &assoc_type.ident);
+
+                        assoc_uses.push(quote!(#assoc_typename as #assoc_typename_rename));
+                    },
+                }
 
                 Ok(assoc_uses)
             },
@@ -44,15 +63,21 @@ pub(super) fn handle(
 fn find_use_path_and_name<'item>(
     mut accumulated_path: Vec<&'item Ident>,
     use_tree: &'item UseTree,
-) -> Result<(Vec<&'item Ident>, &'item UseName)> {
+) -> Result<(Vec<&'item Ident>, NameType<'item>)> {
     match use_tree {
         UseTree::Path(use_path) => {
             accumulated_path.push(&use_path.ident);
             find_use_path_and_name(accumulated_path, &use_path.tree)
         }
-        UseTree::Name(use_name) => Ok((accumulated_path, use_name)),
-        UseTree::Rename(_) | UseTree::Glob(_) | UseTree::Group(_) => {
+        UseTree::Name(use_name) => Ok((accumulated_path, NameType::Name(use_name))),
+        UseTree::Rename(use_rename) => Ok((accumulated_path, NameType::Rename(use_rename))),
+        UseTree::Glob(_) | UseTree::Group(_) => {
             bail!("expected a single item in this import, e.g. `use path::to::Trait`")
         }
     }
+}
+
+enum NameType<'item> {
+    Name(&'item UseName),
+    Rename(&'item UseRename),
 }

--- a/src/proc_macros/gat-attr/trait_use.rs
+++ b/src/proc_macros/gat-attr/trait_use.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+pub(super) fn handle(
+    assoc_type_use: ItemUse,
+    assoc_types: &Punctuated<NestedMeta, syn::token::Comma>,
+) -> Result<TokenStream2> {
+    let (use_segments, use_name) = find_use_path_and_name(Vec::new(), &assoc_type_use.tree)?;
+    let trait_name = &use_name.ident;
+
+    let assoc_typenames = assoc_types
+        .iter()
+        .map(|nested_meta| {
+            if let NestedMeta::Meta(Meta::Path(Path {
+                segments: assoc_type_path,
+                ..
+            })) = nested_meta
+            {
+                Ok(assoc_type_path)
+            } else {
+                bail!("expected `#[gat(Item, …)]`")
+            }
+        })
+        .try_fold::<_, _, std::result::Result<_, Error>>(
+            Vec::<Ident>::with_capacity(assoc_types.len()),
+            |mut assoc_uses, assoc_type_path| {
+                let assoc_type_path = assoc_type_path?;
+                let assoc_type = assoc_type_path
+                    .last()
+                    .expect("Expected exactly one segment in the path");
+                let assoc_typename =
+                    combine_trait_name_and_assoc_type(trait_name, &assoc_type.ident);
+                assoc_uses.push(assoc_typename);
+
+                Ok(assoc_uses)
+            },
+        )?;
+
+    Ok(quote! {
+        #assoc_type_use
+        use #(#use_segments :: )* { #(#assoc_typenames,)* };
+    })
+}
+
+fn find_use_path_and_name<'item>(
+    mut accumulated_path: Vec<&'item Ident>,
+    use_tree: &'item UseTree,
+) -> Result<(Vec<&'item Ident>, &'item UseName)> {
+    match use_tree {
+        UseTree::Path(use_path) => {
+            accumulated_path.push(&use_path.ident);
+            find_use_path_and_name(accumulated_path, &use_path.tree)
+        }
+        UseTree::Name(use_name) => Ok((accumulated_path, use_name)),
+        UseTree::Rename(_) | UseTree::Glob(_) | UseTree::Group(_) => {
+            bail!("expected a single item in this import, e.g. `use path::to::Trait`")
+        }
+    }
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -26,20 +26,28 @@ type Item<'lt, I> = Gat!(<I as LendingIterator>::Item<'lt>);
 
 struct Infinite;
 
-#[gat]
-impl LendingIterator for Infinite {
-    type Item<'next>
-    where
-        Self : 'next,
-    =
-        &'next mut Self
-    ;
+mod infinite_impl {
+    use super::Infinite;
+    use nougat::{gat, Gat};
 
-    fn next (
-        self: &'_ mut Self,
-    ) -> Option<&'_ mut Self>
-    {
-        Some(self)
+    #[gat(Item)]
+    use super::LendingIterator;
+
+    #[gat]
+    impl LendingIterator for Infinite {
+        type Item<'next>
+        where
+            Self : 'next,
+        =
+            &'next mut Self
+        ;
+
+        fn next (
+            self: &'_ mut Self,
+        ) -> Option<&'_ mut Self>
+        {
+            Some(self)
+        }
     }
 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -57,29 +57,43 @@ struct WindowsMut<Slice, const WIDTH: usize> {
     start: usize,
 }
 
-#[gat]
-impl<'lt, T, const WIDTH: usize>
-    LendingIterator
-for
-    WindowsMut<&'lt mut [T], WIDTH>
-{
-    type Item<'next>
-    where
-        Self : 'next,
-    =
-        &'next mut [T; WIDTH]
-    ;
+mod lending_iterator_impl {
+    use {
+        ::core::convert::TryInto,
+        ::nougat::{
+            gat,
+            Gat
+        }
+    };
+    use super::WindowsMut;
 
-    fn next (self: &'_ mut WindowsMut<&'lt mut [T], WIDTH>)
-      -> Option<&'_ mut [T; WIDTH]>
+    #[gat(Item)]
+    use super::LendingIterator as LendingIteratorRenamed;
+
+    #[gat]
+    impl<'lt, T, const WIDTH: usize>
+        LendingIteratorRenamed
+    for
+        WindowsMut<&'lt mut [T], WIDTH>
     {
-        let to_yield =
-            self.slice
-                .get_mut(self.start ..)?
-                .get_mut(.. WIDTH)?
+        type Item<'next>
+        where
+            Self : 'next,
+        =
+            &'next mut [T; WIDTH]
         ;
-        self.start += 1;
-        Some(to_yield.try_into().unwrap())
+
+        fn next (self: &'_ mut WindowsMut<&'lt mut [T], WIDTH>)
+          -> Option<&'_ mut [T; WIDTH]>
+        {
+            let to_yield =
+                self.slice
+                    .get_mut(self.start ..)?
+                    .get_mut(.. WIDTH)?
+            ;
+            self.start += 1;
+            Some(to_yield.try_into().unwrap())
+        }
     }
 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -22,6 +22,23 @@ trait LendingIterator {
     ;
 }
 
+#[gat]
+trait MultiLendingIterator {
+    type Item1<'next>
+    where
+        Self : 'next,
+    ;
+    type Item2<'next>
+    where
+        Self : 'next,
+    ;
+
+    fn next (
+        self: &'_ mut Self,
+    ) -> Option<(Self::Item1<'_>, Self::Item2<'_>)>
+    ;
+}
+
 type Item<'lt, I> = Gat!(<I as LendingIterator>::Item<'lt>);
 
 struct Infinite;
@@ -35,6 +52,8 @@ mod infinite_impl {
     // UseTree::Path / UseTree::Name
     #[gat(Item)]
     use super::LendingIterator;
+    #[gat(Item1, Item2)]
+    use super::MultiLendingIterator;
 
     #[gat]
     impl LendingIterator for Infinite {
@@ -52,6 +71,30 @@ mod infinite_impl {
             Some(self)
         }
     }
+
+    #[gat]
+    impl MultiLendingIterator for Infinite {
+        type Item1<'next>
+        where
+            Self : 'next,
+        =
+            &'next Self
+        ;
+
+        type Item2<'next>
+        where
+            Self : 'next,
+        =
+            &'next Self
+        ;
+
+        fn next (
+            self: &'_ mut Self,
+        ) -> Option<(&'_ Self, &'_ Self)>
+        {
+            Some((self, self))
+        }
+    }
 }
 
 mod infinite2_impl {
@@ -61,6 +104,8 @@ mod infinite2_impl {
     // UseTree::Rename
     #[gat(Item)]
     use super::LendingIterator as LendingIteratorRenamed;
+    #[gat(Item1, Item2)]
+    use super::MultiLendingIterator as MultiLendingIteratorRenamed;
 
     #[gat]
     impl LendingIteratorRenamed for Infinite2 {
@@ -78,6 +123,30 @@ mod infinite2_impl {
             Some(self)
         }
     }
+
+    #[gat]
+    impl MultiLendingIteratorRenamed for Infinite2 {
+        type Item1<'next>
+        where
+            Self : 'next,
+        =
+            &'next Self
+        ;
+
+        type Item2<'next>
+        where
+            Self : 'next,
+        =
+            &'next Self
+        ;
+
+        fn next (
+            self: &'_ mut Self,
+        ) -> Option<(&'_ Self, &'_ Self)>
+        {
+            Some((self, self))
+        }
+    }
 }
 
 mod infinite3_impl {
@@ -87,6 +156,8 @@ mod infinite3_impl {
     // UseTree::Group
     #[gat(Item)]
     use super::{LendingIterator as LendingIteratorRenamed};
+    #[gat(Item1, Item2)]
+    use super::{MultiLendingIterator as MultiLendingIteratorRenamed};
 
     #[gat]
     impl LendingIteratorRenamed for Infinite3 {
@@ -102,6 +173,30 @@ mod infinite3_impl {
         ) -> Option<&'_ mut Self>
         {
             Some(self)
+        }
+    }
+
+    #[gat]
+    impl MultiLendingIteratorRenamed for Infinite3 {
+        type Item1<'next>
+        where
+            Self : 'next,
+        =
+            &'next Self
+        ;
+
+        type Item2<'next>
+        where
+            Self : 'next,
+        =
+            &'next Self
+        ;
+
+        fn next (
+            self: &'_ mut Self,
+        ) -> Option<(&'_ Self, &'_ Self)>
+        {
+            Some((self, self))
         }
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -105,7 +105,7 @@ mod infinite2_impl {
     #[gat(Item)]
     use super::LendingIterator as LendingIteratorRenamed;
     #[gat(Item1, Item2)]
-    use super::MultiLendingIterator as MultiLendingIteratorRenamed;
+    use super::{MultiLendingIterator as MultiLendingIteratorRenamed};
 
     #[gat]
     impl LendingIteratorRenamed for Infinite2 {


### PR DESCRIPTION
Proof of concept implementation of #8.

I haven't tested both exports / imports, and it should be possible to support renames.
