### PR TITLE
Make `Gat!` handle `impl for<'any> Trait<Assoc<'any> = …>` as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "f26a8d2502d5aa4d411ef494ba7470eb299f05725179ce3b5de77aa01a9ffdea"
 
 [[package]]
 name = "nougat"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "macro_rules_attribute",
  "nougat-proc_macros",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "nougat-proc_macros"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "nougat"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.2.1"  # Keep in sync
+version = "0.2.2"  # Keep in sync
 edition = "2018"
 
 license = "Zlib OR MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ polonius-the-crab.optional = true
 
 [dependencies.nougat-proc_macros]
 path = "src/proc_macros"
-version = "0.2.1"  # Keep in sync
+version = "0.2.2"  # Keep in sync
 
 [dev-dependencies]
 

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -8,7 +8,7 @@ name = "nougat-proc_macros"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"
 ]
-version = "0.2.1"  # Keep in sync
+version = "0.2.2"  # Keep in sync
 edition = "2018"
 
 license = "Zlib OR MIT OR Apache-2.0"

--- a/src/proc_macros/adju-gat-e.rs
+++ b/src/proc_macros/adju-gat-e.rs
@@ -26,15 +26,28 @@ impl visit_mut::VisitMut for ApplyGatToEachTypePathOccurrence {
     )
     {
         visit_mut::visit_type_mut(self, type_); // subrecurse
-        if let Type::Path(ref type_path) = *type_ {
-            match Gat::Gat(Gat::Input::TypePath(type_path.clone())) {
-                | Ok(modified_type_path) => {
-                    // Trick: using `Verbatim` over `parse2` skips a layer
-                    // of unnecessary parsing.
-                    *type_ = Type::Verbatim(modified_type_path);
-                },
-                | Err(()) => {},
-            }
+        match *type_ {
+            | Type::Path(ref type_path) => {
+                match Gat::Gat(Gat::Input::TypePath(type_path.clone())) {
+                    | Ok(modified_type_path) => {
+                        // Trick: using `Verbatim` over `parse2` skips a layer
+                        // of unnecessary parsing.
+                        *type_ = Type::Verbatim(modified_type_path);
+                    },
+                    | Err(()) => {},
+                }
+            },
+            | Type::ImplTrait(ref impl_trait) => {
+                match Gat::Gat(Gat::Input::TypeImpl(impl_trait.clone())) {
+                    | Ok(modified_type_path) => {
+                        // Trick: using `Verbatim` over `parse2` skips a layer
+                        // of unnecessary parsing.
+                        *type_ = Type::Verbatim(modified_type_path);
+                    },
+                    | Err(()) => {},
+                }
+            },
+            | _ => {},
         }
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -310,3 +310,11 @@ where
         })
     }
 }
+
+#[apply(Gat!)]
+fn return_impl_ty<T> (slice: &'_ mut [T])
+  -> impl '_ + for<'n> LendingIterator<Item<'n> = &'n mut [T; 2]>
+{
+
+    WindowsMut::<_, 2> { slice, start: 0 }
+}


### PR DESCRIPTION
Allows for `-> Gat!(impl '_ + for<'n> LendingIterator<Item<'n> = …>` (and also the `#[apply(Gat!)]` at-the-top-of-the-item variant)