### PR TITLE
Handle gat binding constraints in remaining positions (trait bounds)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "f26a8d2502d5aa4d411ef494ba7470eb299f05725179ce3b5de77aa01a9ffdea"
 
 [[package]]
 name = "nougat"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "macro_rules_attribute",
  "nougat-proc_macros",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "nougat-proc_macros"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "nougat"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
-version = "0.2.2"  # Keep in sync
+version = "0.2.3"  # Keep in sync
 edition = "2018"
 
 license = "Zlib OR MIT OR Apache-2.0"
@@ -35,7 +35,7 @@ polonius-the-crab.optional = true
 
 [dependencies.nougat-proc_macros]
 path = "src/proc_macros"
-version = "0.2.2"  # Keep in sync
+version = "0.2.3"  # Keep in sync
 
 [dev-dependencies]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@
 pub use ::nougat_proc_macros::gat;
 
 /// Refer to a `<Type as Trait>::Assoc<…>` type.
+/// Or express `Trait<Assoc<…> = …>` constraints.
 ///
 /// Indeed, the GATs defined by <code>[#\[gat\]]</code>, when outside of a
 /// <code>[#\[gat\]]</code>-annotated item (or a

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -8,7 +8,7 @@ name = "nougat-proc_macros"
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"
 ]
-version = "0.2.2"  # Keep in sync
+version = "0.2.3"  # Keep in sync
 edition = "2018"
 
 license = "Zlib OR MIT OR Apache-2.0"

--- a/src/proc_macros/adju-gat-e.rs
+++ b/src/proc_macros/adju-gat-e.rs
@@ -50,4 +50,22 @@ impl visit_mut::VisitMut for ApplyGatToEachTypePathOccurrence {
             | _ => {},
         }
     }
+
+    fn visit_type_param_mut (
+        self: &'_ mut ApplyGatToEachTypePathOccurrence,
+        type_param: &'_ mut TypeParam,
+    )
+    {
+        visit_mut::visit_type_param_mut(self, type_param); // subrecurse
+        crate::Gat::handle_trait_bounds(&mut type_param.bounds);
+    }
+
+    fn visit_predicate_type_mut (
+        self: &'_ mut ApplyGatToEachTypePathOccurrence,
+        predicate_type: &'_ mut PredicateType,
+    )
+    {
+        visit_mut::visit_predicate_type_mut(self, predicate_type); // subrecurse
+        crate::Gat::handle_trait_bounds(&mut predicate_type.bounds);
+    }
 }

--- a/src/proc_macros/adju-gat-e.rs
+++ b/src/proc_macros/adju-gat-e.rs
@@ -68,4 +68,13 @@ impl visit_mut::VisitMut for ApplyGatToEachTypePathOccurrence {
         visit_mut::visit_predicate_type_mut(self, predicate_type); // subrecurse
         crate::Gat::handle_trait_bounds(&mut predicate_type.bounds);
     }
+
+    fn visit_item_trait_mut (
+        self: &'_ mut ApplyGatToEachTypePathOccurrence,
+        item_trait: &'_ mut ItemTrait,
+    )
+    {
+        visit_mut::visit_item_trait_mut(self, item_trait); // subrecurse
+        crate::Gat::handle_trait_bounds(&mut item_trait.supertraits);
+    }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -337,3 +337,15 @@ fn for_<T> ()
     takes_impl_ty(returns_impl_ty(&mut [(); 0]));
     takes_impl_ty2(returns_impl_ty(&mut [(); 0]));
 }
+
+#[apply(Gat!)]
+trait Foo<T>
+:
+    for<'n> LendingIterator<Item<'n> = &'n mut [T; 2]>
+{}
+
+#[apply(Gat!)]
+impl<X, T> Foo<T> for X
+where
+    Self : for<'n> LendingIterator<Item<'n> = &'n mut [T; 2]>,
+{}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -312,9 +312,28 @@ where
 }
 
 #[apply(Gat!)]
-fn return_impl_ty<T> (slice: &'_ mut [T])
+fn returns_impl_ty<T> (slice: &'_ mut [T])
   -> impl '_ + for<'n> LendingIterator<Item<'n> = &'n mut [T; 2]>
 {
-
     WindowsMut::<_, 2> { slice, start: 0 }
+}
+
+#[apply(Gat!)]
+fn takes_impl_ty<T> (
+    _: impl for<'n> LendingIterator<Item<'n> = &'n mut [T; 2]>,
+)
+{}
+
+#[apply(Gat!)]
+fn takes_impl_ty2<T, I> (
+    _: I,
+)
+where
+    I : for<'n> LendingIterator<Item<'n> = &'n mut [T; 2]>,
+{}
+
+fn for_<T> ()
+{
+    takes_impl_ty(returns_impl_ty(&mut [(); 0]));
+    takes_impl_ty2(returns_impl_ty(&mut [(); 0]));
 }


### PR DESCRIPTION
  - Previous PR made `Gat!(impl for<'n> LendingIterator<Item<'n> = …>)` work (and also with `#[apply(Gat!)]`, of course);
  - Current PR uses `#[apply(Gat!)]` call-site syntax to also handle `: for<'n> LendingIterator<Item<'n> = …>` bounds